### PR TITLE
Hyperlink DOI to preferred resolver

### DIFF
--- a/app/views/datasets/show.html.haml
+++ b/app/views/datasets/show.html.haml
@@ -34,7 +34,7 @@
       .ds_doi.text-center.auto.cell
         - if @dataset.doi
           DOI:
-          = link_to @dataset.doi, "https://dx.doi.org/#{@dataset.doi}"
+          = link_to @dataset.doi, "https://doi.org/#{@dataset.doi}"
         - elsif can_edit?(@dataset) && @dataset.doi.blank?
           = link_to 'Mint DOI', mint_doi_dataset_path(@dataset),
                     :method => :post,

--- a/spec/requests/datasets_spec.rb
+++ b/spec/requests/datasets_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Datasets', :type => :request, elasticsearch: true do
       click_link('Mint DOI')
       expect(page).to have_link(
         'doi:10.5072/FK2W66HS5K',
-        href: 'https://dx.doi.org/doi:10.5072/FK2W66HS5K'
+        href: 'https://doi.org/doi:10.5072/FK2W66HS5K'
       )
       expect(page).not_to have_link('Mint DOI')
       ds1.update_attributes(doi: nil)


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!